### PR TITLE
feat: implement support of BestEffort Qos class

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ You need to customize values.yaml for your requirements, for exemple ours is:
 deploymentEasyappointment:
   image: highcanfly/easyappointments
   language: french
+  resources:
+    limits:
+      cpu: '2'
+      memory: 1Gi
 
 ingressEasyappointments:
   ingressClassName: haproxy            # see https://www.haproxy.com/documentation/kubernetes/
@@ -20,4 +24,17 @@ ingressEasyappointments:
   clusterIssuer: our-ca-issuer         # see https://cert-manager.io/
 secretMysql:
   root: cGFzc3dvcmQ=                   # echo -n "password" | openssl enc -a
+
+mysql:
+  resources:
+    limits:
+      cpu: '1'
+      memory: 2Gi
+
+smtpd:
+  smtpd:
+    resources:
+      limits:
+        cpu: 900m
+        memory: "322122547"
 ```

--- a/helm/easyappointments/templates/deployment-easyappointment.yaml
+++ b/helm/easyappointments/templates/deployment-easyappointment.yaml
@@ -59,9 +59,7 @@ spec:
             - containerPort: 8888
               protocol: TCP
           resources:
-            limits:
-              cpu: '2'
-              memory: 1Gi
+            {{- toYaml .Values.deploymentEasyappointment.resources | nindent 12 }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/helm/easyappointments/templates/deployment-mysql.yaml
+++ b/helm/easyappointments/templates/deployment-mysql.yaml
@@ -42,9 +42,7 @@ spec:
             - containerPort: 3306
               protocol: TCP
           resources:
-            limits:
-              cpu: '1'
-              memory: 2Gi
+            {{- toYaml .Values.mysql.resources | nindent 12 }}
           securityContext:
             runAsGroup: 0
             runAsUser: 0

--- a/helm/easyappointments/templates/deployment-smtpd.yaml
+++ b/helm/easyappointments/templates/deployment-smtpd.yaml
@@ -75,5 +75,5 @@ spec:
         name: smtpd
         ports:
         - containerPort: 25
-        resources: {{- toYaml .Values.smtpd.smtpd.resources | nindent 10 }}
+        resources: {{- toYaml .Values.smtpd.smtpd.resources | nindent 12 }}
        

--- a/helm/easyappointments/values.yaml
+++ b/helm/easyappointments/values.yaml
@@ -39,10 +39,6 @@ smtpd:
     image:
       repository: highcanfly/smtp-relay
       tag: latest
-    resources:
-      limits:
-        cpu: 900m
-        memory: "322122547"
   smtpdAllowedSenderDomains: "example.org example.net example.com"
   smtpdDkimPrivateKey: "-----BEGIN RSA PRIVATE KEY-----|MIIEowIBAAKCAQEA8h4OyvWHRHEre/JHWjwyL3YLC7Mjf13C8WSZtNX5K5PrAsz+|FFankVsKClLf7rpItKRaaeLQM98yiRkW47w4sBKJjXgEtI+KwB54N26YEPUJ7KpA|TAACL2dxhMlhvGkDEVB1h3CMwyV27oq3KQeCsdhuOSykQTh0FBDbA9K7S32G2uNv|D4ff7JGSKez8j+6gjk2CfDIWnayoIPmrldPo+qo7xFjJCfjlq4qXqLMGMScZKOqA|kQV9+v0AM52sBcPP7j3ZUHV4yNv26nE3iCtZbfatNbMwBaoaXXFby5iU3n7SlLwY|aIHg2/Woi027ht/zt+2UTU5oTFkh6DqA/pCWdwIDAQABAoIBAC2xHnmO/IgeE2bA|wlZ1JcNvM4ZxuDFBMJj9s0Q9XVisAZ31sb2E3PrBg5OPMFONNEti+O0isMgZRyA4|a+lujAQue2cHT1wD+ttm5KkRZgFNPSI8vwWYutDXZMT6fEdiSgHqfUOiKe5qE5fQ|9d/4WuHVRnfjxNvKG53t0GdYTaBhIiYFBoc4Sollg4iRMkzwRZngV6fD3SfZZ9Oh|iBttbdKFYz90Nn9RgxLPtXNPPEY7KkKpCIjED7Vz7RZrGyc7I+1JzViEL/wpYHaK|i915sEwimfYnJzwAUf/VR2gHd7GjhLnh9YAi/icPCHYlTefHLb4NKzXSEpAvjaGR|Dz6tjoECgYEA/ZcmA/q0KzbJUSekGZUss9L/0hHTfeIe856oacYBVgfc0qPk/RJL|12tXzT4aODAUvY1sXcWPCka95iam3Hbcz4ZyPlREor7nkghTzfAWp8B9pCqtKbnP|Ob63+60swRb5nPXS/6KHzfHXORtjjhJVnkrfSnvr9+tHzdjOc8vvtvsCgYEA9GsA|YzX4GVpgU+z90M2qBwQKGOZSkodsQ07KjmBusr4UKcWOKvE3xPibRY1GBN3QHLqO|IcOVvQdL9xAbNS5mRhwAtHASMRr7ay1lOmae10+wjAIPBTzLr0V8nsRdQt3O7iPn|yOqPzSjFBwJXYdd1BiqYMpLZKHeLPyxC+AIC9bUCgYBKWtc6s3fAc//zW7wyBBtn|XqbD4ZYxguuwYwTefsBFiWimGog56/Nw5niIJX1qnC54pc7wb8zRJoznvs2ONwvn|jXRR8kNttKwRlX99EriR107/o8PCSEkKlXE8yjolI6ds7mc/rVhEenSwuecm8RlJ|oIp4PH2j48jaAogGS/WtoQKBgG+FryyVgHmY+iDxHrK6VJ1U44KO/RgswGJJvjSO|nZPjFPImWQMRA0BVqwtmNY+c4gtpt9aCFn2kqa22ZKO0YygUOOIbzMEpLZSupuSp|1Eor60NG4TGjltCHZSBQOrl62aNhMK5FEI4szxGuqM5U7+l7X+ybgohrW1bczEW7|LTyNAoGBAOex2DsnK1LqKpokQN3aq3UTwe35xPcW1KyjY5VlccytELhtpShCFUfi|9g3QIiwpFHt0jabsWxyGELg5tPsdXbs5/5JjtzCY7aBf+w46ADNbZQ/rM2wfcsfb|vv/IYdrmKzYGxQ5cJdEHwK1OxYwW6SJRukfgAeLyWhvQR+afnI6/|-----END RSA PRIVATE KEY-----"    # openssl genrsa -out /dev/stdout 2048 | tr '\n' '|' | sed 's/.$//'
   smtpdDkimSelector: "easy_selector" 


### PR DESCRIPTION
Hello @eltorio 

Thank you for contributing this impressive work. 
I tested the deployment on a minimal cluster, but encountered a failure due to the requirement of Guaranteed QoS class for all components, resulting in a demand for 3 CPUs at 100%, while I only had one available. 

To address this issue, I made modifications to the code, allowing the components to function under the BestEffort QoS class when using an empty `resources: {} `configuration for all. 

**Please note that the default behavior remains unchanged,** as I included all the resource limits from your example in the values.yaml file, which appears to trigger the Guaranteed QoS class.

Regards,
Bill M